### PR TITLE
Make fetch_groups use a separate admin service account

### DIFF
--- a/google/backend.go
+++ b/google/backend.go
@@ -55,6 +55,14 @@ func newBackend() *backend {
 						Type:        framework.TypeBool,
 						Description: "Fetch Google Groups",
 					},
+					impersonationPropertyName: &framework.FieldSchema{
+						Type:        framework.TypeString,
+						Description: "Google Account to impersonate for admin API access",
+					},
+					adminServiceAccountPropertyName: &framework.FieldSchema{
+						Type:        framework.TypeString,
+						Description: "Google Service Account with organisation-wide delegation for admin API access (JSON file base64 encoded)",
+					},
 				},
 
 				Callbacks: map[logical.Operation]framework.OperationFunc{


### PR DESCRIPTION
The former way how fetch_groups worked wasn't much usable. It used the
user token to look up the groups in the admin directory API. This means
all users need to have access to the admin API which is usually a bad
idea.

This new approach uses a separate service account for the group lookups
so the authenticating users don't need any permission on that API.